### PR TITLE
#37 프로젝트 시작하기, 완료하기, 내보내기 기능 추가

### DIFF
--- a/src/main/java/dev/sodev/domain/member/repository/MemberProjectRepository.java
+++ b/src/main/java/dev/sodev/domain/member/repository/MemberProjectRepository.java
@@ -16,4 +16,6 @@ public interface MemberProjectRepository extends JpaRepository<MemberProject, Lo
     Optional<MemberProject> findAllByMemberId(Long memberId);
 
     MemberProject getReferenceByMemberId(Long memberId);
+
+    void deleteByProject_IdAndMember_Id(Long projectId, Long memberId);
 }

--- a/src/main/java/dev/sodev/domain/project/Project.java
+++ b/src/main/java/dev/sodev/domain/project/Project.java
@@ -7,6 +7,8 @@ import dev.sodev.domain.likes.Likes;
 import dev.sodev.domain.member.Member;
 import dev.sodev.domain.member.MemberProject;
 import dev.sodev.domain.project.dto.requset.ProjectInfoRequest;
+import dev.sodev.global.exception.ErrorCode;
+import dev.sodev.global.exception.SodevApplicationException;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -30,8 +32,9 @@ public class Project extends BaseEntity {
     private Integer be;
     private Integer fe;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
-    private ProjectState state;
+    private ProjectState state = ProjectState.RECRUIT;
 
     private String registeredBy;
 
@@ -69,6 +72,20 @@ public class Project extends BaseEntity {
         this.startDate = request.start_date();
         this.endDate = request.end_date();
         this.recruitDate = request.recruit_date();
+    }
+
+    public void startProject() {
+        if (!this.state.equals(ProjectState.RECRUIT)) {
+            throw new SodevApplicationException(ErrorCode.BAD_REQUEST, "프로젝트 모집 단계에서만 시작할 수 있습니다.");
+        }
+        this.state = ProjectState.PROGRESS;
+    }
+
+    public void completeProject() {
+        if (!this.state.equals(ProjectState.PROGRESS)) {
+            throw new SodevApplicationException(ErrorCode.BAD_REQUEST, "프로젝트 진행 단계에서만 완료할 수 있습니다.");
+        }
+        this.state = ProjectState.COMPLETE;
     }
 
 }

--- a/src/main/java/dev/sodev/domain/project/controller/ProjectController.java
+++ b/src/main/java/dev/sodev/domain/project/controller/ProjectController.java
@@ -84,9 +84,24 @@ public class ProjectController {
         projectService.declineApplicant(projectId, memberProjectDto);
     }
 
+    @PostMapping("/{projectId}/kicks")
+    public void kickMember(@PathVariable Long projectId, @RequestBody MemberProjectDto memberProjectDto) {
+        projectService.kickMember(projectId, memberProjectDto);
+    }
+
     @PostMapping("/review/{memberId}")
-    public Response<Void> projectReview(@PathVariable Long memberId,@RequestBody PeerReviewRequest request) {
+    public Response<Void> projectReview(@PathVariable Long memberId, @RequestBody PeerReviewRequest request) {
         projectService.evaluationMembers(memberId, request);
         return Response.success();
+    }
+
+    @PostMapping("/{projectId}/start")
+    public void startProject(@PathVariable Long projectId) {
+        projectService.startProject(projectId);
+    }
+
+    @PostMapping("/{projectId}/complete")
+    public void completeProject(@PathVariable Long projectId) {
+        projectService.completeProject(projectId);
     }
 }

--- a/src/main/java/dev/sodev/domain/project/dto/ProjectDto.java
+++ b/src/main/java/dev/sodev/domain/project/dto/ProjectDto.java
@@ -1,6 +1,7 @@
 package dev.sodev.domain.project.dto;
 
 import dev.sodev.domain.comment.dto.CommentDto;
+import dev.sodev.domain.enums.ProjectState;
 import dev.sodev.domain.likes.dto.LikesMemberDto;
 import dev.sodev.domain.member.dto.MemberProjectDto;
 import dev.sodev.domain.project.Project;
@@ -21,6 +22,7 @@ public class ProjectDto {
     private Long id;
     private Integer be;
     private Integer fe;
+    private ProjectState state;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private LocalDateTime recruitDate;
@@ -44,6 +46,7 @@ public class ProjectDto {
                 .id(project.getId())
                 .be(project.getBe())
                 .fe(project.getFe())
+                .state(project.getState())
                 .startDate(project.getStartDate())
                 .endDate(project.getEndDate())
                 .recruitDate(project.getRecruitDate())

--- a/src/main/java/dev/sodev/domain/project/repository/ProjectSkillCustomRepositoryImpl.java
+++ b/src/main/java/dev/sodev/domain/project/repository/ProjectSkillCustomRepositoryImpl.java
@@ -53,7 +53,7 @@ public class ProjectSkillCustomRepositoryImpl implements ProjectSkillCustomRepos
                                 Projections.fields(ProjectDto.class, list(Projections.fields(SkillDto.class, skill.name)).as("skills"),
                                         project.id, project.registeredBy,
                                         project.fe, project.be,
-                                        project.title, project.content,
+                                        project.title, project.content, project.state,
                                         project.startDate, project.endDate, project.recruitDate,
                                         project.createdAt, project.createdBy,
                                         project.modifiedAt, project.modifiedBy)));

--- a/src/main/java/dev/sodev/domain/project/service/ProjectService.java
+++ b/src/main/java/dev/sodev/domain/project/service/ProjectService.java
@@ -54,5 +54,11 @@ public interface ProjectService {
 
     void declineApplicant(Long projectId, MemberProjectDto memberProjectDto); // 프로젝트 지원자 거절
 
-    void evaluationMembers(Long memberId, PeerReviewRequest request);
+    void kickMember(Long projectId, MemberProjectDto memberProjectDto); // 참여인원 내보내기
+
+    void evaluationMembers(Long memberId, PeerReviewRequest request); // 프로젝트 완료 후 동료평가
+
+    void startProject(Long projectId); // 프로젝트 시작
+
+    void completeProject(Long projectId); // 프로젝트 종료
 }


### PR DESCRIPTION
* ProjectController 내보내기, 시작하기, 완료하기 api를 추가하였다. @PathVariable 로 프로젝트 id 를 받아서 조회한 후 요청자와 작성자가 일치하는지 확인하는 로직이 들어간다.

* ProjectDto 프로젝트 조회 했을 때 현재 프로젝트의 상태를 나타내는 state 가 빠져있어서 추가.

* Project state 초기값을 RECURIT 상태로 생성되도록 @Builder.Default 를 추가하고, 시작하기 완료하기 메서드를 작성했다.

* ProjectService, ProjectServiceImpl 내보내기 -> 내보낼 대상의 역할이 CREATOR 면 에러. 요청자가  CREATOR 면 에러. cascade 로 인해 MemberProject 가 사라지면 회원과 프로젝트 안에 있는 리스트들도 같이 삭제.

시작하기, 완료하기 -> 요청자가 프로젝트 게시물 작성자인지 확인한 후에 처리하도록 로직 작성.