### PR TITLE
데이터베이스 테이블에 index 추가하여 성능개선

### DIFF
--- a/src/main/java/dev/sodev/domain/alarm/Alarm.java
+++ b/src/main/java/dev/sodev/domain/alarm/Alarm.java
@@ -14,7 +14,7 @@ import org.hibernate.annotations.Where;
 @Getter
 @Entity
 @Table(name = "alarm", indexes = {
-        @Index(name = "member_id_idx", columnList = "member_id")
+        @Index(name = "id_alarm_member", columnList = "member_id")
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/dev/sodev/domain/comment/Comment.java
+++ b/src/main/java/dev/sodev/domain/comment/Comment.java
@@ -1,7 +1,6 @@
 package dev.sodev.domain.comment;
 
 import dev.sodev.domain.BaseEntity;
-import dev.sodev.domain.comment.dto.request.CommentRequest;
 import dev.sodev.domain.member.Member;
 import dev.sodev.domain.project.Project;
 import jakarta.persistence.*;
@@ -15,6 +14,10 @@ import java.util.Optional;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "comment", indexes = {
+        @Index(name = "idx_comment_member", columnList = "member_id"),
+        @Index(name = "idx_comment_project", columnList = "project_id")
+})
 @Entity
 public class Comment extends BaseEntity {
 

--- a/src/main/java/dev/sodev/domain/comment/repsitory/CommentCustomRepositoryImpl.java
+++ b/src/main/java/dev/sodev/domain/comment/repsitory/CommentCustomRepositoryImpl.java
@@ -2,7 +2,6 @@ package dev.sodev.domain.comment.repsitory;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import dev.sodev.domain.comment.Comment;
-import dev.sodev.domain.project.Project;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/dev/sodev/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/dev/sodev/domain/comment/service/CommentServiceImpl.java
@@ -42,10 +42,12 @@ public class CommentServiceImpl implements CommentService {
             comment.confirmParent(commentRepository.findById(request.parentId()).orElseThrow(() -> new SodevApplicationException(ErrorCode.COMMENT_NOT_FOUND)));
         }
         commentRepository.save(comment);
-
         CommentDto commentDto = CommentDto.of(comment);
 
-        return CommentResponse.builder().message("댓글 작성이 완료됐습니다.").comment(commentDto).build();
+        return CommentResponse.builder()
+                .message("댓글 작성이 완료됐습니다.")
+                .comment(commentDto)
+                .build();
     }
 
     @Override
@@ -53,7 +55,11 @@ public class CommentServiceImpl implements CommentService {
         Project project = projectRepository.findById(projectId).orElseThrow(() -> new SodevApplicationException(ErrorCode.FEED_NOT_FOUND));
         List<Comment> comments = commentRepository.findAllByProject(projectId);
         List<CommentDto> commentDtos = comments.stream().map(CommentDto::of).toList();
-        return CommentListResponse.builder().message("해당 게시글의 댓글 조회가 완료됐습니다.").comments(commentDtos).build();
+
+        return CommentListResponse.builder()
+                .message("해당 게시글의 댓글 조회가 완료됐습니다.")
+                .comments(commentDtos)
+                .build();
     }
 
     @Transactional
@@ -61,7 +67,11 @@ public class CommentServiceImpl implements CommentService {
     public CommentResponse updateComment(Long projectId, CommentRequest request) {
         Comment comment = checkCondition(projectId, request.id());
         comment.updateContent(request.content());
-        return CommentResponse.builder().message("댓글 수정이 완료됐습니다.").comment(CommentDto.of(comment)).build();
+
+        return CommentResponse.builder()
+                .message("댓글 수정이 완료됐습니다.")
+                .comment(CommentDto.of(comment))
+                .build();
     }
 
 
@@ -74,7 +84,9 @@ public class CommentServiceImpl implements CommentService {
         List<Comment> removableCommentList = comment.findRemovableList();
         commentRepository.deleteAll(removableCommentList);
 
-        return CommentResponse.builder().message("댓글 삭제가 완료됐습니다.").build();
+        return CommentResponse.builder()
+                .message("댓글 삭제가 완료됐습니다.")
+                .build();
     }
 
     @Override
@@ -84,7 +96,11 @@ public class CommentServiceImpl implements CommentService {
 
         List<Comment> allByMemberEmail = commentRepository.findAllByMemberEmail(member.getEmail());
         List<CommentDto> comments = allByMemberEmail.stream().map(CommentDto::of).toList();
-        return CommentListResponse.builder().message("회원님이 작성하신 댓글들의 조회를 완료했습니다.").comments(comments).build();
+
+        return CommentListResponse.builder()
+                .message("회원님이 작성하신 댓글들의 조회를 완료했습니다.")
+                .comments(comments)
+                .build();
     }
 
     @Override
@@ -93,13 +109,18 @@ public class CommentServiceImpl implements CommentService {
 
         List<Comment> allByMemberEmail = commentRepository.findAllByMemberId(member.getId());
         List<CommentDto> comments = allByMemberEmail.stream().map(CommentDto::of).toList();
-        return CommentListResponse.builder().message("요청하신 작성자의 댓글들을 조회했습니다.").comments(comments).build();
+
+        return CommentListResponse.builder()
+                .message("요청하신 작성자의 댓글들을 조회했습니다.")
+                .comments(comments)
+                .build();
     }
 
     private Comment checkCondition(Long projectId, Long commentId) {
         Member member = memberRepository.findByEmail(SecurityUtil.getMemberEmail()).orElseThrow(() -> new SodevApplicationException(ErrorCode.MEMBER_NOT_FOUND));
         Project project = projectRepository.findById(projectId).orElseThrow(() -> new SodevApplicationException(ErrorCode.FEED_NOT_FOUND));
         Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new SodevApplicationException(ErrorCode.COMMENT_NOT_FOUND));
+
         if (comment.isRemoved()) {
             throw new SodevApplicationException(ErrorCode.BAD_REQUEST, "이미 삭제된 댓글입니다");
         } else if (!comment.getMember().getId().equals(member.getId())) { // id로 비교해야 추후 회원이 이메일 변경을 하여도 원래 댓글 작성자와 같은지 비교 가능함.

--- a/src/main/java/dev/sodev/domain/follow/Follow.java
+++ b/src/main/java/dev/sodev/domain/follow/Follow.java
@@ -7,9 +7,13 @@ import lombok.*;
 
 @Builder
 @Getter
-@Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "follow", indexes = {
+        @Index(name = "idx_follow_from_member", columnList = "from_member"),
+        @Index(name = "idx_follow_to_member", columnList = "to_member")
+})
+@Entity
 public class Follow extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/dev/sodev/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/dev/sodev/domain/follow/repository/FollowRepository.java
@@ -6,15 +6,8 @@ import dev.sodev.domain.follow.Follow;
 import dev.sodev.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
-
-//    List<Follow> findAllByFromMember(Member fromMember);
-//
-//    List<Follow> findAllByToMember(Member toMember);
-//
-//    void deleteByFromMemberAndToMember(Member fromMember, Member toMember);
 
     Follow findByFromMemberAndToMember(Member fromMember, Member toMember);
 

--- a/src/main/java/dev/sodev/domain/likes/Likes.java
+++ b/src/main/java/dev/sodev/domain/likes/Likes.java
@@ -10,9 +10,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "likes", indexes = {
+        @Index(name = "idx_likes_member", columnList = "member_id"),
+        @Index(name = "idx_likes_project", columnList = "project_id"),
+        @Index(name = "idx_likes_member_project", columnList = "member_id, project_id")
+})
+@Entity
 public class Likes extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/dev/sodev/domain/likes/repository/LikeCustomRepositoryImpl.java
+++ b/src/main/java/dev/sodev/domain/likes/repository/LikeCustomRepositoryImpl.java
@@ -1,20 +1,14 @@
 package dev.sodev.domain.likes.repository;
 
 import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import dev.sodev.domain.likes.Likes;
-import dev.sodev.domain.likes.QLikes;
 import dev.sodev.domain.likes.dto.LikesMemberDto;
 import dev.sodev.domain.likes.dto.LikesProjectDto;
-import dev.sodev.domain.project.Project;
-import dev.sodev.domain.project.QProject;
-import dev.sodev.domain.project.dto.ProjectDto;
-import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -25,18 +19,10 @@ import static dev.sodev.domain.project.QProject.*;
 
 
 @Repository
+@RequiredArgsConstructor
 public class LikeCustomRepositoryImpl implements LikeCustomRepository{
 
-    private final EntityManager em;
     private final JPAQueryFactory queryFactory;
-    private final JdbcTemplate jdbcTemplate;
-
-
-    public LikeCustomRepositoryImpl(EntityManager em, JdbcTemplate jdbcTemplate) {
-        this.em = em;
-        this.queryFactory = new JPAQueryFactory(JPQLTemplates.DEFAULT,em);
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     public Likes isProjectLikes(Long id, Long projectId) {

--- a/src/main/java/dev/sodev/domain/member/Member.java
+++ b/src/main/java/dev/sodev/domain/member/Member.java
@@ -6,15 +6,11 @@ import dev.sodev.domain.comment.Comment;
 import dev.sodev.domain.enums.Auth;
 import dev.sodev.domain.follow.Follow;
 import dev.sodev.domain.likes.Likes;
-import dev.sodev.global.exception.ErrorCode;
-import dev.sodev.global.exception.SodevApplicationException;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,7 +36,8 @@ public class Member extends BaseEntity {
     @Column(unique = true)
     private String nickName;
     private String phone;
-    private String introduce;
+    @Builder.Default
+    private String introduce = "asd";
 
     @Builder.Default
     @OneToMany(mappedBy = "toMember", cascade = CascadeType.REMOVE, orphanRemoval = true)

--- a/src/main/java/dev/sodev/domain/member/MemberProject.java
+++ b/src/main/java/dev/sodev/domain/member/MemberProject.java
@@ -12,9 +12,13 @@ import lombok.NoArgsConstructor;
 import org.hibernate.Hibernate;
 
 @Getter
-@Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "member_project", indexes = {
+        @Index(name = "idx_member_project_member", columnList = "member_id"),
+        @Index(name = "idx_member_project_project", columnList = "project_id")
+})
+@Entity
 public class MemberProject extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/dev/sodev/domain/member/MemberSkill.java
+++ b/src/main/java/dev/sodev/domain/member/MemberSkill.java
@@ -1,15 +1,18 @@
 package dev.sodev.domain.member;
 
-import dev.sodev.domain.BaseEntity;
 import dev.sodev.domain.skill.Skill;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
-@Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "member_skill", indexes = {
+        @Index(name = "idx_member_skill_member", columnList = "member_id"),
+        @Index(name = "idx_member_skill_skill", columnList = "skill_id")
+})
+@Entity
 public class MemberSkill {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/dev/sodev/domain/project/ProjectSkill.java
+++ b/src/main/java/dev/sodev/domain/project/ProjectSkill.java
@@ -1,15 +1,17 @@
 package dev.sodev.domain.project;
 
-import dev.sodev.domain.BaseEntity;
 import dev.sodev.domain.skill.Skill;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
-@Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "project_skill", indexes = {
+        @Index(name = "idx_project_skill", columnList = "skill_id")
+})
+@Entity
 public class ProjectSkill {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/dev/sodev/domain/review/Review.java
+++ b/src/main/java/dev/sodev/domain/review/Review.java
@@ -9,9 +9,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "review", indexes = {
+        @Index(name = "idx_review_member", columnList = "member_id")
+})
+@Entity
 public class Review extends BaseEntity {
 
     @Id

--- a/src/main/java/dev/sodev/domain/skill/Skill.java
+++ b/src/main/java/dev/sodev/domain/skill/Skill.java
@@ -6,9 +6,9 @@ import lombok.*;
 
 
 @Getter
-@Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Entity
 public class Skill extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
엔티티에 JPA 어노테이션 `@Table`, `@Index` 를 사용하여 각 엔티티에 맞게 컬럼을 선택하여 단일, 결합 인덱스를 설정했다.

this closes #44 