### PR TITLE
#50 서비스 레이어 비즈니스 로직 도메인 모델 패턴 적용

### DIFF
--- a/src/main/java/dev/sodev/domain/alarm/service/AlarmService.java
+++ b/src/main/java/dev/sodev/domain/alarm/service/AlarmService.java
@@ -15,14 +15,6 @@ public interface AlarmService {
 
     Slice<AlarmDto> alarmList(Pageable pageable);
 
-    List<Member> alarmsToOne(Member member);
-
-    List<Member> alarmsToMember(Project project);
-
-    List<Member> alarmsToFollower(Member member);
-
-    List<Member> alarmsToLikes(Project project);
-
     void sendAlarms(AlarmEvent event);
 
     SseEmitter connectAlarm(String memberEmail);

--- a/src/main/java/dev/sodev/domain/follow/Follow.java
+++ b/src/main/java/dev/sodev/domain/follow/Follow.java
@@ -37,4 +37,11 @@ public class Follow extends BaseEntity {
         this.toMember = toMember;
         toMember.getFollowers().remove(this);
     }
+
+    public static Follow getFollow(Member fromMember, Member toMember) {
+        return Follow.builder()
+                .fromMember(fromMember)
+                .toMember(toMember)
+                .build();
+    }
 }

--- a/src/main/java/dev/sodev/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/dev/sodev/domain/member/service/MemberServiceImpl.java
@@ -92,8 +92,7 @@ public class MemberServiceImpl implements MemberService {
         }
 
         Member member = getMemberBySecurity();
-
-        updateMemberInfo(request, member);
+        member.updateMemberInfo(request);
 
         return new MemberUpdateResponse("회원정보 수정이 완료됐습니다.");
     }
@@ -127,12 +126,5 @@ public class MemberServiceImpl implements MemberService {
     private Member getMemberBySecurity() {
         return memberRepository.findByEmail(getMemberEmail()).orElseThrow(() ->
                 new SodevApplicationException(ErrorCode.MEMBER_NOT_FOUND));
-    }
-
-    private static void updateMemberInfo(MemberUpdateRequest request, Member member) {
-        member.updateNickName(request.nickName());
-        member.updatePhone(request.phone());
-        member.updateIntroduce(request.introduce());
-        member.updateImage(request.memberImage());
     }
 }

--- a/src/main/java/dev/sodev/domain/project/Project.java
+++ b/src/main/java/dev/sodev/domain/project/Project.java
@@ -2,9 +2,12 @@ package dev.sodev.domain.project;
 
 import dev.sodev.domain.BaseEntity;
 import dev.sodev.domain.comment.Comment;
+import dev.sodev.domain.enums.ProjectRole;
 import dev.sodev.domain.enums.ProjectState;
 import dev.sodev.domain.likes.Likes;
+import dev.sodev.domain.member.Member;
 import dev.sodev.domain.member.MemberProject;
+import dev.sodev.domain.member.dto.MemberProjectDto;
 import dev.sodev.domain.project.dto.requset.ProjectInfoRequest;
 import dev.sodev.global.exception.ErrorCode;
 import dev.sodev.global.exception.SodevApplicationException;
@@ -73,6 +76,59 @@ public class Project extends BaseEntity {
             throw new SodevApplicationException(ErrorCode.BAD_REQUEST, "프로젝트 진행 단계에서만 완료할 수 있습니다.");
         }
         this.state = ProjectState.COMPLETE;
+    }
+
+    // 지원자의 memberProject 반환.
+    public MemberProject getApplicantMemberProject(Member applicant) {
+        return this.getApplicants().stream()
+                .filter(mp -> mp.getMember().equals(applicant))
+                .findFirst()
+                .orElseThrow(() -> new SodevApplicationException(ErrorCode.BAD_REQUEST));
+    }
+
+    // Member 의 MemberProject 존재하는지 확인.
+    public MemberProject getMemberProject(Member member) {
+        return this.members.stream()
+                .filter(mp -> mp.getMember().equals(member))
+                .findAny()
+                .orElseThrow(() -> new SodevApplicationException(ErrorCode.BAD_REQUEST));
+    }
+
+    // 해당 프로젝트의 직무 자리가 남아있는지 확인.
+    public void isJoinable(MemberProjectDto memberProjectDto) {
+        long size = this.getMembers().stream()
+                .filter(m -> m.getProjectRole().getRoleType().equals(memberProjectDto.role().getRoleType()))
+                .count();
+
+        if (memberProjectDto.role().getRoleType().equals(ProjectRole.RoleType.BE)) { // 백앤드인 경우
+            if (this.getBe() - size <= 0) {
+                throw new SodevApplicationException(ErrorCode.RECRUITMENT_EXCEED);
+            }
+        } else { // 프론트앤드인 경우
+            if (this.getFe() - size <= 0) {
+                throw new SodevApplicationException(ErrorCode.RECRUITMENT_EXCEED);
+            }
+        }
+    }
+
+    // 동료평가시 평가하려는 회원의 프로젝트가 완료된 상태인지, 같은 프로젝트를 진행했는지 확인.
+    public void isEvaluationAvailable(Project writerProject) {
+        if (!this.getState().equals(ProjectState.COMPLETE) ||
+                !this.getId().equals(writerProject.getId())) {
+            throw new SodevApplicationException(ErrorCode.BAD_REQUEST);
+        }
+    }
+
+    public List<Member> alarmsToMember() {
+        return this.getMembers().stream()
+                .filter(mp -> !mp.getProjectRole().getRole().equals(ProjectRole.Role.APPLICANT))
+                .map(MemberProject::getMember)
+                .distinct()
+                .toList();
+    }
+
+    public List<Member> alarmsToLikes() {
+        return this.getLikes().stream().map(Likes::getMember).toList();
     }
 
     public void update(ProjectInfoRequest request) {

--- a/src/main/java/dev/sodev/domain/project/dto/requset/ProjectInfoRequest.java
+++ b/src/main/java/dev/sodev/domain/project/dto/requset/ProjectInfoRequest.java
@@ -1,14 +1,10 @@
 package dev.sodev.domain.project.dto.requset;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import dev.sodev.domain.enums.ProjectRole;
 import dev.sodev.domain.enums.ProjectState;
 import dev.sodev.domain.member.Member;
 import dev.sodev.domain.project.Project;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Future;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -19,48 +15,36 @@ import java.util.List;
 @Schema(description = "Project Feed Request")
 public record ProjectInfoRequest(
 
-//        @NotNull(message = "인원수를 입력해주세요.")
         @Schema(description = "백엔드 인원수", example = "3")
         Integer be,
 
-//        @NotNull(message = "인원수를 입력해주세요.")
         @Schema(description = "프론트엔드 인원수", example = "2")
         Integer fe,
 
-//        @NotNull(message = "프로젝트 시작일을 선택해주세요.")
-//        @Future(message = "기간을 현재보다 과거로 지정할 수 없습니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         @Schema(description = "프로젝트 시작 일시", example = "2023-08-30 09:00:00", type = "string")
         LocalDateTime startDate,
 
-//        @NotNull(message = "프로젝트 종료일을 선택해주세요.")
-//        @Future(message = "기간을 현재보다 과거로 지정할 수 없습니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         @Schema(description = "프로젝트 종료 일시", example = "2023-09-30 18:00:00", type = "string")
         LocalDateTime endDate,
 
-//        @NotNull(message = "프로젝트 모집기간을 선택해주세요")
-//        @Future(message = "기간을 현재보다 과거로 지정할 수 없습니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         @Schema(description = "프로젝트 모집 일시", example = "2023-08-25 00:00:00", type = "string")
         LocalDateTime recruitDate,
 
-//        @NotBlank(message = "제목은 공백이 불가합니다.")
         @Schema(description = "프로젝트 제목", example = "간단한 SNS 플랫폼 프로젝트 진행하려고 합니다~")
         String title,
 
-//        @NotBlank(message = "내용을 입력해주세요.")
         @Schema(description = "프로젝트 내용", example = "개발 입문하신 초보자 분들 같이 프로젝트 하면서 공부하면서 만들려고 합니다!")
         String content,
 
-//        @NotNull(message = "사용 스킬을 최소 한개 이상 입력해주세요.")
         @Schema(description = "프로젝트 사용 기술", example = "[ \"java\", \"kotlin\", \"node.js\", \"python\", \"c\"]")
         List<String> skillSet,
 
-//        @NotNull
         @Schema(description = "프로젝트 지원 역할(BE or FE)", example = "BE")
         String roleType
 ) {

--- a/src/main/java/dev/sodev/global/security/service/AuthService.java
+++ b/src/main/java/dev/sodev/global/security/service/AuthService.java
@@ -37,13 +37,13 @@ import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 @Service
 public class AuthService {
 
-    private final String GRANT_TYPE_BEARER = "Bearer";
-    private final String CACHE_NAME_PREFIX = CacheName.MEMBER + "::";
-    private final long TWO_WEEKS = 1000 * 60 * 60 * 12 * 14;
+    private static final String GRANT_TYPE_BEARER = "Bearer";
+    private static final String CACHE_NAME_PREFIX = CacheName.MEMBER + "::";
+    private static final long TWO_WEEKS = 1000 * 60 * 60 * 12 * 14;
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
@@ -75,6 +75,7 @@ public class AuthService {
     }
 
     // 토큰 재발급
+    @Transactional
     public JsonWebTokenDto reissue(String refreshToken) {
         Claims claims = parseAndValidRefreshToken(refreshToken);
         Member member = getMemberByEmail(claims.getSubject());
@@ -86,6 +87,7 @@ public class AuthService {
     }
 
     // 로그아웃
+    @Transactional
     public void logout(String accessToken, String refreshToken) {
         Claims claims = parseAndValidRefreshToken(refreshToken);
         String resolvedAccessToken = resolveToken(accessToken);
@@ -96,6 +98,7 @@ public class AuthService {
     }
 
     // 회원탈퇴
+    @Transactional
     public void withdrawal(MemberWithdrawal memberWithdrawal, String accessToken, String refreshToken) {
         String memberEmail = SecurityUtil.getMemberEmail();
         Member member = getMemberWithComments(memberEmail);


### PR DESCRIPTION
* AlarmService, AlarmServiceImpl 알람 수신 대상을 반환하는 메서드들을 서비스 레이어에서 제거하고 Member, Project 도메인에 비즈니스 로직을 갖게 수정.

* FollowServiceImpl, Follow Follow 도메인에 fromMember, toMember 를 받아서 Follow 객체를 반환하는 메서드 추가.

FollowServiceImpl에 요청자 본인을 대상으로 팔로우, 언팔로우 요청시 반환하는 에러에 들어가는 메서드를 상수로 정의. 기존 isOtherMember(request, fromMember, message)로 정의돼있던 메서드를 fromMember의 타입 Member 도메인 안에서 로직을 수행하도록 변경. follow(), unfollow() 메서드의 로직을 Member 도메인 안에서 수행하도록 변경.

* MemberServiceImpl, Member 서비스에 회원의 정보를 변경하는 updateMemberInfo(request, member) 메서드를 비즈니스 로직의 주체인 Member 도메인이 갖게 변경.

Member 도메인이 각 서비스에서 비즈니스 로직의 주체가 된다면 Member가 메서드를 가지고있을 수 있도록 메서드들을 추가.

* ProjectServiceImpl, Project 프로젝트에 참여 가능한지 검증하는 메서드인isJoinable(memberProjectDto, project, applicantMemberProject) 를 행위 주체인 Project 도메인이 가지도록 수정.

회원이 프로젝트 참여인원으로 있는지 확인하는 getMemberProject(member) 메서드를 Project 도메인이 갖도록 수정.

프로젝트 동료평가시 해당 프로젝트가 평가진행이 가능한 상태인지 검증하는 isEvaluationAvailable(Project writerProject) 메서드를 Project 도메인이 갖도록 수정.